### PR TITLE
Add MyApp wrapper for running tests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,11 +4,19 @@ import 'core/theme/app_theme.dart';
 import 'core/router/app_router.dart';
 
 void main() {
-  runApp(
-    const ProviderScope(
+  runApp(const MyApp());
+}
+
+/// Root widget that provides the [ProviderScope] for the application.
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ProviderScope(
       child: HealthcareApp(),
-    ),
-  );
+    );
+  }
 }
 
 class HealthcareApp extends ConsumerWidget {


### PR DESCRIPTION
## Summary
- add `MyApp` as the root widget that provides `ProviderScope`
- run the app via `MyApp`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866647304488322b7d79e969c5e9dd6